### PR TITLE
Update Conan conventions for 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 linux: &linux
    os: linux
-   dist: xenial
+   dist: bionic
    language: python
    python: "3.7"
    services:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 
@@ -12,7 +11,6 @@ class RubyInstallerConan(ConanFile):
     homepage = "https://www.ruby-lang.org/"
     description = "Ruby is an interpreted, high-level, general-purpose programming language"
     topics = ("conan", "installer", "ruby", "gem")
-    author = "Bincrafters <bincrafters@gmail.com>"
     exports = "LICENSE.md"
     _autotools = None
 
@@ -30,11 +28,11 @@ class RubyInstallerConan(ConanFile):
 
     def requirements(self):
         if self.settings.os_build == "Linux":
-            self.requires("zlib/1.2.11@conan/stable")
+            self.requires("zlib/1.2.11")
 
     def build_requirements(self):
         if self.settings.os_build == "Windows":
-            self.build_requires("7z_installer/1.0@conan/stable")
+            self.build_requires("7zip/19.00")
 
     def source(self):
         sha256 = "28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 from conans import ConanFile
 


### PR DESCRIPTION
cf https://github.com/bincrafters/community/issues/1069#issuecomment-566254780

> ```
> ERROR: Conflict in ruby_installer/2.5.5@bincrafters/stable
>     Requirement zlib/1.2.11@conan/stable conflicts with already defined zlib/1.2.11
>     To change it, override it in your base requirements
> ```
> 
> ruby_installer stable/2.5.5 references the old one, so does stable/2.6.3, while testing/2.6.3 is fine
> 
> https://github.com/bincrafters/conan-ruby_installer/blob/stable/2.5.5/conanfile.py#L33
> https://github.com/bincrafters/conan-ruby_installer/blob/stable/2.6.3/conanfile.py#L33
> https://github.com/bincrafters/conan-ruby_installer/blob/testing/2.6.3/conanfile.py#L31

